### PR TITLE
Allow type="ets" for ili forecasting

### DIFF
--- a/man/forecast_ili.Rd
+++ b/man/forecast_ili.Rd
@@ -8,6 +8,7 @@ forecast_ili(
   ilidat,
   horizon = 4L,
   trim_date = NULL,
+  type = "arima",
   constrained = TRUE,
   param_space = list(P = 0, D = 0, Q = 0, p = 1:2, d = 0:2, q = 0)
 )
@@ -18,6 +19,8 @@ forecast_ili(
 \item{horizon}{Optional horizon periods through which the forecasts should be generated; default is \code{4}}
 
 \item{trim_date}{Earliest start date you want to use for ILI data. Default \code{NULL} doesn't trim.}
+
+\item{type}{Either "arima" or "ets" to fit a \link[fable:ARIMA]{fable::ARIMA} or \link[fable:ETS]{fable::ETS} model. If using "ets", the \code{constrained} and \code{param_space} arguments are ignored.}
 
 \item{constrained}{Should the model be constrained to a non-seasonal model? If \code{TRUE} the parameter space defined in "param_space" argument will be used. See \link[fable:ARIMA]{fable::ARIMA}.}
 
@@ -32,7 +35,7 @@ A named list containing:
 \item \code{ili_forecast}: The forecast from \link[fabletools:forecast]{fabletools::forecast} at the specified horizon.
 \item \code{ili_future}: The \code{horizon}-number of weeks of ILI data forecasted into the future.
 \item \code{ili_bound}: The data in 1 bound to the data in 5.
-\item \code{arima_params}: A tibble with ARIMA model parameters for each location.
+\item \code{arima_params}: A tibble with ARIMA model parameters for each location (if \code{type="arima"}).
 \item \code{locstats}: A tibble with missing data information on all locations.
 \item \code{removed}: A tibble with locations removed because of high missing ILI data.
 }
@@ -100,6 +103,17 @@ tail(ilifor_us$ili_bound, 10)
 library(dplyr)
 library(ggplot2)
 theme_set(theme_classic())
+ilifor_hhs$ili_bound \%>\%
+  mutate(date=cdcfluview::mmwr_week_to_date(epiyear, epiweek)) \%>\%
+  filter(date>"2021-08-01") \%>\%
+  ggplot(aes(date, ili, col=forecasted)) +
+  geom_line(lwd=.3) +
+  geom_point(aes(col=forecasted), size=.7) +
+  facet_wrap(~abbreviation, scale="free_y")
+
+## hhs using exponential smoothing model
+ilidat_hhs <- ilidat \%>\% dplyr::filter(region_type=="HHS Regions")
+ilifor_hhs <- forecast_ili(ilidat_hhs, horizon=4L, type="ets", trim_date="2019-01-01")
 ilifor_hhs$ili_bound \%>\%
   mutate(date=cdcfluview::mmwr_week_to_date(epiyear, epiweek)) \%>\%
   filter(date>"2021-08-01") \%>\%


### PR DESCRIPTION
This could be made much more flexible, but I added a `type` argument to `forecast_ili` that defaults to `type="arima"` so that existing code isn't affected, but allows for `type="ets"`, where it'll fit a nonseasonal exponential smoothing model.  

Just looking at HHS regions, the arima model does some weird with some locations:

![image](https://user-images.githubusercontent.com/460076/147683689-53bd4c99-1618-493f-8749-5217788a0cf6.png)

Using `type="ets"`, I get what I think are more plausible forecasts at the HHS level.

![image](https://user-images.githubusercontent.com/460076/147683750-a6a38c1f-afbe-4fe6-b4df-57a0c4ee0e51.png)

The code use to generate these forecasts and figures are in the examples for `?forecast_ili`.

