### PR TITLE
submission script edits

### DIFF
--- a/submission/submission.R
+++ b/submission/submission.R
@@ -224,7 +224,7 @@ all_prepped$forecast_date <- this_monday()
 validate_forecast(all_prepped)
 
 all_prepped %>%
-  write_csv(., paste0("submission/SigSci-CREG/", this_monday(), "-SigSci-CREG.csv"))
+  write_csv(., paste0("submission/SigSci-CREG/", this_monday(), "-SigSci-CREG.candidate.csv"))
 
 bound_truth <-
   do.call("rbind", datl) %>%
@@ -266,7 +266,7 @@ formatted_list <- format_for_submission(hosp_fitfor$tsfor, method = "ts")
 formatted_list$arima$forecast_date <- this_monday()
 validate_forecast(formatted_list$arima)
 # formatted_list$arima %>%
-#   write_csv(., paste0("submission/SigSci-TSENS/", this_monday(), "-SigSci-TSENS-ARIMA.csv"))
+#   write_csv(., paste0("submission/SigSci-TSENS/", this_monday(), "-SigSci-TSENS-ARIMA.candidate.csv"))
 
 pdf(paste0("submission/SigSci-TSENS/artifacts/plots/SigSci-TSENS-ARIMA-", this_monday(), ".pdf"), width=11.5, height=8)
 for(loc in unique(formatted_list$arima$location)) {
@@ -280,7 +280,7 @@ dev.off()
 formatted_list$ets$forecast_date <- this_monday()
 validate_forecast(formatted_list$ets)
 # formatted_list$ets %>%
-#   write_csv(., paste0("submission/SigSci-TSENS/", this_monday(), "-SigSci-TSENS-ETS.csv"))
+#   write_csv(., paste0("submission/SigSci-TSENS/", this_monday(), "-SigSci-TSENS-ETS.candidate.csv"))
 
 pdf(paste0("submission/SigSci-TSENS/artifacts/plots/SigSci-TSENS-ETS-", this_monday(), ".pdf"), width=11.5, height=8)
 for(loc in unique(formatted_list$ets$location)) {
@@ -294,7 +294,7 @@ dev.off()
 formatted_list$ensemble$forecast_date <- this_monday()
 validate_forecast(formatted_list$ensemble)
 formatted_list$ensemble %>%
-  write_csv(., paste0("submission/SigSci-TSENS/", this_monday(), "-SigSci-TSENS.csv"))
+  write_csv(., paste0("submission/SigSci-TSENS/", this_monday(), "-SigSci-TSENS.candidate.csv"))
 
 pdf(paste0("submission/SigSci-TSENS/artifacts/plots/SigSci-TSENS-ensemble-", this_monday(), ".pdf"), width=11.5, height=8)
 for(loc in unique(formatted_list$ensemble$location)) {


### PR DESCRIPTION
this PR will bring in some minor edits to the submission script:

- no longer using `tidyverse` in submission.R and instead calling `dplyr`, `readr`, etc independently since they are already pkg deps
- added a flag near top of script to specify n_workers for parellelization
- changing formatted forecast output file naming convention to be `*.candidate.csv` instead of `*.csv`