### PR TITLE
multiple forecasts in single plot_forecast call

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -161,14 +161,14 @@ replace_ili_nowcast <- function(ilidat, weeks_to_replace=1) {
 #' # What are the last four weeks of recorded data?
 #' last4 <-
 #'   prepped_hosp_all %>%
-#'   distinct(week_start) %>%
-#'   arrange(week_start) %>%
+#'   dplyr::distinct(week_start) %>%
+#'   dplyr::arrange(week_start) %>%
 #'   tail(4)
 #'
 #' #remove those
 #' prepped_hosp <-
-#'   prepped_hosp %>%
-#'   anti_join(last4, by="week_start")
+#'   prepped_hosp_all %>%
+#'   dplyr::anti_join(last4, by="week_start")
 #'
 #' # Make a tsibble
 #' prepped_hosp_tsibble <- make_tsibble(prepped_hosp,
@@ -200,8 +200,25 @@ replace_ili_nowcast <- function(ilidat, weeks_to_replace=1) {
 #' plot_forecast(prepped_hosp_all, hosp_formatted$ets)
 #' plot_forecast(prepped_hosp, hosp_formatted$arima)
 #' plot_forecast(prepped_hosp_all, hosp_formatted$arima)
-#' }
 #'
+#' # Demonstrating multiple models
+#' prepped_hosp <-
+#'   h_raw %>%
+#'   prep_hdgov_hosp(statesonly=TRUE, min_per_week = 0, remove_incomplete = TRUE) %>%
+#'   dplyr::filter(abbreviation != "DC")
+#'
+#' tsens_20220110 <- readr::read_csv(here::here("submission/SigSci-TSENS/2022-01-10-SigSci-TSENS.csv"))
+#' creg_20220110 <- readr::read_csv(here::here("submission/SigSci-CREG/2022-01-10-SigSci-CREG.csv"))
+#' combo_20220110 <- dplyr::bind_rows(
+#'   dplyr::mutate(tsens_20220110, model = "SigSci-TSENS"),
+#'   dplyr::mutate(creg_20220110, model = "SigSci-CREG")
+#' )
+#' plot_forecast(prepped_hosp, combo_20220110, location = "24")
+#' plot_forecast(prepped_hosp, tsens_20220110, location = "24")
+#' plot_forecast(prepped_hosp, combo_20220110, location = c("34","36"))
+#' plot_forecast(prepped_hosp, creg_20220110, location = "US", .model = "SigSci-CREG")
+#' plot_forecast(prepped_hosp, creg_20220110, location = "US", .model = "SigSci-CREG")
+#' }
 plot_forecast <- function(.data, submission, location="US", pi = TRUE, .model = NULL) {
 
   if(!is.null(.model)) {

--- a/man/fiphde-package.Rd
+++ b/man/fiphde-package.Rd
@@ -6,9 +6,7 @@
 \alias{fiphde-package}
 \title{fiphde: Forecasting Influenza in Support of Public Health Decision Making}
 \description{
-Miscellaneous functions for retrieving data, creating and evaluating time series 
-    forecasting models for influenza-like illness (ILI) and influenza hospitalizations in 
-    the United States.
+Miscellaneous functions for retrieving data, creating and evaluating time series forecasting models for influenza-like illness (ILI) and influenza hospitalizations in the United States.
 }
 \author{
 \strong{Maintainer}: VP Nagraj \email{pnagraj@signaturescience.com} (\href{https://orcid.org/0000-0003-0060-566X}{ORCID})

--- a/man/plot_forecast.Rd
+++ b/man/plot_forecast.Rd
@@ -36,14 +36,14 @@ prepped_hosp_all <- prep_hdgov_hosp(h_raw)
 # What are the last four weeks of recorded data?
 last4 <-
   prepped_hosp_all \%>\%
-  distinct(week_start) \%>\%
-  arrange(week_start) \%>\%
+  dplyr::distinct(week_start) \%>\%
+  dplyr::arrange(week_start) \%>\%
   tail(4)
 
 #remove those
 prepped_hosp <-
-  prepped_hosp \%>\%
-  anti_join(last4, by="week_start")
+  prepped_hosp_all \%>\%
+  dplyr::anti_join(last4, by="week_start")
 
 # Make a tsibble
 prepped_hosp_tsibble <- make_tsibble(prepped_hosp,
@@ -75,6 +75,23 @@ plot_forecast(prepped_hosp, hosp_formatted$ets)
 plot_forecast(prepped_hosp_all, hosp_formatted$ets)
 plot_forecast(prepped_hosp, hosp_formatted$arima)
 plot_forecast(prepped_hosp_all, hosp_formatted$arima)
-}
 
+# Demonstrating multiple models
+prepped_hosp <-
+  h_raw \%>\%
+  prep_hdgov_hosp(statesonly=TRUE, min_per_week = 0, remove_incomplete = TRUE) \%>\%
+  dplyr::filter(abbreviation != "DC")
+
+tsens_20220110 <- readr::read_csv(here::here("submission/SigSci-TSENS/2022-01-10-SigSci-TSENS.csv"))
+creg_20220110 <- readr::read_csv(here::here("submission/SigSci-CREG/2022-01-10-SigSci-CREG.csv"))
+combo_20220110 <- dplyr::bind_rows(
+  dplyr::mutate(tsens_20220110, model = "SigSci-TSENS"),
+  dplyr::mutate(creg_20220110, model = "SigSci-CREG")
+)
+plot_forecast(prepped_hosp, combo_20220110, location = "24")
+plot_forecast(prepped_hosp, tsens_20220110, location = "24")
+plot_forecast(prepped_hosp, combo_20220110, location = c("34","36"))
+plot_forecast(prepped_hosp, creg_20220110, location = "US", .model = "SigSci-CREG")
+plot_forecast(prepped_hosp, creg_20220110, location = "US", .model = "SigSci-CREG")
+}
 }


### PR DESCRIPTION
this PR is going to bring in an important new feature for our `plot_forecast()` function . the draft version of the function on this branch is able to plot multiple forecasts on the same panel alongside observed data. this **will** cause breaking changes in existing code. so we need to review and consider carefully.

tagging you for review @stephenturner 