### PR TITLE
Quasipoisson, categorical plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Imports: 
     dplyr,
     fable,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fiphde
 Title: Forecasting Influenza in Support of Public Health Decision Making
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: 
     c(person(given = "VP",
              family = "Nagraj",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# fiphde 0.3.4
+
+- Fix issue in `forecast_categorical()` where there were no records for rows having zero probability.
+- Add categorical plots to submission script.
+- Limit submission script to quasipoisson only.
+
 # fiphde 0.3.3
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
 # fiphde 0.3.4
 
-- Fix issue in `forecast_categorical()` where there were no records for rows having zero probability.
-- Add categorical plots to submission script.
-- Limit submission script to quasipoisson only.
+## New features
+
+This release makes two minor updates to the submission script. The script now includes plots of categorical forecasts to help wit downstream forecast review. Additionally, the script is now configured to only use the quasipoisson model family in the count regression grid search procedure.
+
+## Bug fixes
+
+Previously the `forecast_categorical()` function would only include probabilities for the "type_id" values (e.g., increase, large_decrease, etc.) that were observed in at least one location. As of this release we now include all "type_id" values, assigning those that were not observed in any location to probability of 0.
 
 # fiphde 0.3.3
 

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -522,8 +522,9 @@ forecast_categorical <- function(.forecast, .observed) {
     sum(.)
 
   ## join prepped forecast and prepped observed
-  dplyr::left_join(forc4exp,hosp4exp) %>%
-    dplyr::left_join(rate_change) %>%
+  res <-
+    dplyr::left_join(forc4exp,hosp4exp, by="location") %>%
+    dplyr::left_join(rate_change, by="location") %>%
     ## calculate component indicators
     dplyr::mutate(
       ind_count = abs(value - lag_value),

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -553,4 +553,21 @@ forecast_categorical <- function(.forecast, .observed) {
                   type = "category") %>%
     dplyr::select(forecast_date, target,location, type, type_id, value)
 
+  # What are the names of the categories to forecast?
+  categories <- c("large_decrease", "decrease", "stable", "increase", "large_increase")
+  # Which ones are missing from the data?
+  missing_from_res <- categories[!categories %in% res$type_id]
+  # Fill those in with zeros
+  add_to_res <- tidyr::crossing(forecast_date=unique(res$forecast_date),
+                                target=unique(res$target),
+                                location=unique(res$location),
+                                type=unique(res$type),
+                                type_id=missing_from_res,
+                                value=0)
+  # Bind to the existing data, and make type_id a factor for possible plotting
+  res <-
+    res %>%
+    dplyr::bind_rows(add_to_res) %>%
+    dplyr::arrange(location) %>%
+    dplyr::mutate(type_id=factor(type_id, levels=categories))
 }

--- a/submission/submission.R
+++ b/submission/submission.R
@@ -341,3 +341,26 @@ tsens_exp <- forecast_categorical(tsens_forc, prepped_hosp)
 write_csv(tsens_exp, paste0("submission/SigSci-TSENS/", this_monday(), "-SigSci-TSENS.candidate.experimental.csv"))
 creg_exp <- forecast_categorical(creg_forc, prepped_hosp)
 write_csv(tsens_exp, paste0("submission/SigSci-CREG/", this_monday(), "-SigSci-CREG.candidate.experimental.csv"))
+
+plot_cat <- function(x) {
+  x %>%
+    inner_join(fiphde:::locations, by="location") %>%
+    select(loc=abbreviation, type_id, value) %>%
+    tidyr::spread(type_id, value) %>%
+    mutate(score=(2*large_increase + increase + (-1)*decrease + (-2)*large_decrease)) %>%
+    mutate(loc=factor(loc) %>% reorder(score)) %>%
+    mutate(loc=loc %>% forcats::fct_relevel("US")) %>%
+    select(-score) %>%
+    tidyr::pivot_longer(-loc, names_to="type_id", values_to="value") %>%
+    mutate(type_id=factor(type_id, levels=c("large_decrease", "decrease", "stable", "increase", "large_increase"))) %>%
+    ggplot(aes(loc, value)) + geom_col(aes(fill=type_id)) +
+    scale_fill_manual(values=c("darkorchid", "cornflowerblue", "gray80", "orange", "red2")) +
+    theme_classic() +
+    theme(legend.position="bottom", legend.title=element_blank()) +
+    labs(x=NULL, y=NULL)
+}
+
+tsens_catplot <- plot_cat(tsens_exp)
+ggsave(paste0("submission/SigSci-TSENS/artifacts/plots/", this_monday(), "-SigSci-TSENS-cat.png"), plot=tsens_catplot, width=12, height=6)
+creg_catplot <- plot_cat(creg_exp)
+ggsave(paste0("submission/SigSci-CREG/artifacts/plots/", this_monday(), "-SigSci-CREG-cat.png"), plot=creg_catplot, width=12, height=6)

--- a/submission/submission.R
+++ b/submission/submission.R
@@ -114,18 +114,18 @@ datl <-
 
 models <-
   list(
-    poisson1 = trending::glm_model(flu.admits ~ p_positive + ili + smoothed_admits, family = "poisson"),
-    poisson2 = trending::glm_model(flu.admits ~ p_positive + ili + offset(flu.admits.cov) + smoothed_admits, family = "poisson"),
-    poisson3 = trending::glm_model(flu.admits ~ ili + smoothed_admits, family = "poisson"),
-    poisson4 = trending::glm_model(flu.admits ~ p_positive + smoothed_admits, family = "poisson"),
+    # poisson1 = trending::glm_model(flu.admits ~ p_positive + ili + smoothed_admits, family = "poisson"),
+    # poisson2 = trending::glm_model(flu.admits ~ p_positive + ili + offset(flu.admits.cov) + smoothed_admits, family = "poisson"),
+    # poisson3 = trending::glm_model(flu.admits ~ ili + smoothed_admits, family = "poisson"),
+    # poisson4 = trending::glm_model(flu.admits ~ p_positive + smoothed_admits, family = "poisson"),
     quasipoisson1 = trending::glm_model(flu.admits ~ p_positive + ili + smoothed_admits, family = "quasipoisson"),
     quasipoisson2 = trending::glm_model(flu.admits ~ p_positive + ili + offset(flu.admits.cov) + smoothed_admits, family = "quasipoisson"),
     quasipoisson3 = trending::glm_model(flu.admits ~ p_positive + smoothed_admits, family = "quasipoisson"),
-    quasipoisson4 = trending::glm_model(flu.admits ~ ili + smoothed_admits, family = "quasipoisson"),
-    negbin1 = trending::glm_nb_model(flu.admits ~ p_positive + ili + smoothed_admits),
-    negbin2 = trending::glm_nb_model(flu.admits ~ p_positive + ili + offset(flu.admits.cov) + smoothed_admits),
-    negbin3 = trending::glm_nb_model(flu.admits ~ ili + smoothed_admits),
-    negbin4 = trending::glm_nb_model(flu.admits ~ p_positive + smoothed_admits)
+    quasipoisson4 = trending::glm_model(flu.admits ~ ili + smoothed_admits, family = "quasipoisson")
+    # negbin1 = trending::glm_nb_model(flu.admits ~ p_positive + ili + smoothed_admits),
+    # negbin2 = trending::glm_nb_model(flu.admits ~ p_positive + ili + offset(flu.admits.cov) + smoothed_admits),
+    # negbin3 = trending::glm_nb_model(flu.admits ~ ili + smoothed_admits),
+    # negbin4 = trending::glm_nb_model(flu.admits ~ p_positive + smoothed_admits)
   )
 
 


### PR DESCRIPTION
- c5c5197bc143b1a67c00555cb037af05888e710b: change submission script to quasipoisson only
- 42cea9c2b8d186ee4adf4956b5fe400316c3104c: add categorical plots to submission script
- c14facb3be9f424c7b27438646dab8ee5f2a1fe0: make sure all categories are in the exp target, even if they're zero.
- Misc other commits for NEWS, DESCRIPTION, etc.

Feel free to mod the plot, or even make a pkg function if you prefer. I'm not married to this color scheme. The sort order is happening here, where large increase/decrease = 2x, sorting by this "score". US is always first, then increasing score where more decreasing states are first, more increasing later.

https://github.com/signaturescience/fiphde/blob/f89ad1e1d546f992d7f1e43fa8ea67837ba08fa2/submission/submission.R#L350

Example CREG 2023-01-16

![image](https://user-images.githubusercontent.com/460076/213520078-37966071-6c47-42a4-8811-ba3760922c36.png)

Example TSENS 2023-01-16

![image](https://user-images.githubusercontent.com/460076/213520234-b19a62d5-b94a-4487-a6c0-c645c687ae70.png)
