### PR TITLE
remove the "remove_null_models" argument from ts_fit_forecast() 

### DIFF
--- a/R/forecast.R
+++ b/R/forecast.R
@@ -11,7 +11,6 @@
 #' @param models A list of right hand side formula contents for models you want to run; default is `list(arima='PDQ(0, 0, 0) + pdq(1:2, 0:2, 0)', ets='season(method="N")', nnetar=NULL)` which runs a constrained ARIMA, non-seasonal ETS, and ignores the NNETAR model; see "Details" for more information
 #' @param covariates Covariates that should be modeled with the time series. Defaults to `c("hosp_rank", "ili_rank")`, from the historical data brought in with [prep_hdgov_hosp].
 #' @param ensemble Logical as to whether or not the models should be ensembled (using mean); default `TRUE`
-#' @param remove_null_models Logical as to whether or null models should be removed; default `TRUE`
 #' @return A list of the time series fit, time series forecast, and model formulas.
 #' - **tsfit**: A `mdl_df` class "mable" with one row for each location, columns for arima and ets models.
 #' - **tsfor**: A `fbl_ts` class "fable" with one row per location-model-timepoint up to `horizon` number of time points.
@@ -64,8 +63,7 @@ ts_fit_forecast <- function(prepped_tsibble,
                                         ets='season(method="N")',
                                         nnetar=NULL),
                             covariates=c("hosp_rank", "ili_rank"),
-                            ensemble=TRUE,
-                            remove_null_models=TRUE) {
+                            ensemble=TRUE) {
 
   if (!is.null(trim_date)) {
     message(sprintf("Trimming to %s", trim_date))

--- a/man/ts_fit_forecast.Rd
+++ b/man/ts_fit_forecast.Rd
@@ -12,8 +12,7 @@ ts_fit_forecast(
   models = list(arima = "PDQ(0, 0, 0) + pdq(1:2, 0:2, 0)", ets =
     "season(method=\\"N\\")", nnetar = NULL),
   covariates = c("hosp_rank", "ili_rank"),
-  ensemble = TRUE,
-  remove_null_models = TRUE
+  ensemble = TRUE
 )
 }
 \arguments{
@@ -30,8 +29,6 @@ ts_fit_forecast(
 \item{covariates}{Covariates that should be modeled with the time series. Defaults to \code{c("hosp_rank", "ili_rank")}, from the historical data brought in with \link{prep_hdgov_hosp}.}
 
 \item{ensemble}{Logical as to whether or not the models should be ensembled (using mean); default \code{TRUE}}
-
-\item{remove_null_models}{Logical as to whether or null models should be removed; default \code{TRUE}}
 }
 \value{
 A list of the time series fit, time series forecast, and model formulas.

--- a/vignettes/basic_usage.Rmd
+++ b/vignettes/basic_usage.Rmd
@@ -136,7 +136,7 @@ prepped_hosp_tsibble
 
 Next, let's fit a time series model and create forecasts using the `ts_fit_forecast` function. This function takes a tsibble created as above, a forecast horizon in weeks, the name of the outcome variable to forecast, and optional covariates to use in the ARIMA model. 
 
-Here we fit a non-seasonal ARIMA model with the autoregressive term (p) restricted to 1:2, order of integration for differencing (d) restricted to 0:2, and the moving average (q) restricted to 0 (see `?fable::ARIMA` for more information). The model also fits a non-seasonal exponential smoothing model (see `?fable::ETS` for details). In this example we do not fit an autoregressive neural network model, but we could change `nnetar=NULL` to `nnetar="AR(P=1)"` to do so (see `?fable::nnetar` for details). We can also trim the data used in modeling, and here we restrict to only include hospitalization data reported after January 1, 2021. By setting `ensemble=TRUE` we create an ensemble model that averages the ARIMA and exponential smoothing models. The `remove_null_models=TRUE` specification identifies models that did not converge and removes those from downstream processing.
+Here we fit a non-seasonal ARIMA model with the autoregressive term (p) restricted to 1:2, order of integration for differencing (d) restricted to 0:2, and the moving average (q) restricted to 0 (see `?fable::ARIMA` for more information). The model also fits a non-seasonal exponential smoothing model (see `?fable::ETS` for details). In this example we do not fit an autoregressive neural network model, but we could change `nnetar=NULL` to `nnetar="AR(P=1)"` to do so (see `?fable::nnetar` for details). We can also trim the data used in modeling, and here we restrict to only include hospitalization data reported after January 1, 2021. By setting `ensemble=TRUE` we create an ensemble model that averages the ARIMA and exponential smoothing models.
 
 ```{r, eval=FALSE}
 hosp_fitfor <- ts_fit_forecast(prepped_hosp_tsibble,
@@ -147,8 +147,7 @@ hosp_fitfor <- ts_fit_forecast(prepped_hosp_tsibble,
                                models=list(arima='PDQ(0, 0, 0) + pdq(1:2, 0:2, 0)',
                                            ets='season(method="N")',
                                            nnetar=NULL), 
-                               ensemble=TRUE, 
-                               remove_null_models=TRUE)
+                               ensemble=TRUE)
 ```
 
 The function will output messages describing the ARIMA and ETS model formulas passed to `fable::ARIMA` and `fable::ETS`.


### PR DESCRIPTION
remove the "remove_null_models" argument from ts_fit_forecast() fixes #156. devtools::check() OK.