### PR TITLE
adding github link to pkg site

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,4 +66,4 @@ Suggests:
 Remotes: signaturescience/rplanes, reichlab/distfromq
 Config/testthat/edition: 3
 VignetteBuilder: knitr
-URL: https://signaturescience.github.io/fiphde/
+URL: https://signaturescience.github.io/fiphde/, https://github.com/signaturescience/fiphde


### PR DESCRIPTION
Added a link to the DESCRIPTION file that when building the website adds the github icon and link in the navbar. 

Checked the package build and was passing:
![image](https://github.com/user-attachments/assets/e0447ff0-4a59-40f5-9ccc-32ddb91df070)
