### PR TITLE
215 fix incorrectly labeled columns in the flusurv hospitalization data retrieval

### DIFF
--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -193,8 +193,8 @@ get_cdc_hosp <- function(years=NULL) {
                      region="US",
                      epiyear=year,
                      epiweek=weeknumber,
-                     week_start=weekend,
-                     week_end=weekstart,
+                     week_end=weekend,
+                     week_start=weekstart,
                      rate,
                      weeklyrate,
                      season=season_label) %>%

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -187,7 +187,7 @@ get_cdc_hosp <- function(years=NULL) {
     dplyr::filter(race_label=="Overall") %>%
     dplyr::filter(sexid == 0) %>%
     dplyr::filter(name == "FluSurv-NET") %>%
-    dplyr::filter(!is.na(weeklyrate)) %>%
+    dplyr::filter(!is.na(weeklyrate) & !is.na(rate)) %>%
     dplyr::transmute(location="US",
                      abbreviation="US",
                      region="US",


### PR DESCRIPTION
this PR fixes the issue with mislabeled columns in `get_cdc_hosp()` and also addresses a problem with missing rate data on retrieval